### PR TITLE
Remove missing externs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo-egl"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["The Servo Project Developers"]
 repository = "https://github.com/servo/rust-egl"
 description = "Wrapper for EGL"

--- a/src/eglext.rs
+++ b/src/eglext.rs
@@ -2,6 +2,9 @@
 
 use libc::*;
 use egl::*;
+use std::ffi;
+use std::mem;
+use std::ptr;
 
 // defines
 pub type EGLImageKHR = *mut c_void;
@@ -42,18 +45,36 @@ extern {}
 pub fn CreateImageKHR(dpy: EGLDisplay, context: EGLContext, target: EGLenum,
                       buffer: EGLClientBuffer, attrib_list: *const EGLint) -> EGLImageKHR {
     unsafe {
+        let name = ffi::CString::new("eglCreateImageKHR").unwrap().as_ptr();
+
+        let addr = eglGetProcAddress(name as *const _);
+
+        if addr == ptr::null() {
+            panic!("Unable to find an entry point for eglCreateImageKHR");
+        }
+
+        let eglCreateImageKHR: extern "C" fn(dpy: EGLDisplay, context: EGLContext, target: EGLenum,
+                                             buffer: EGLClientBuffer, attrib_list: *const EGLint) -> EGLImageKHR = mem::transmute(addr);
         return eglCreateImageKHR(dpy, context, target, buffer, attrib_list);
     }
 }
 
 pub fn DestroyImageKHR(dpy: EGLDisplay, image: EGLImageKHR) -> EGLBoolean {
     unsafe {
+        let name = ffi::CString::new("eglDestroyImageKHR").unwrap().as_ptr();
+
+        let addr = eglGetProcAddress(name as *const _);
+
+        if addr == ptr::null() {
+            panic!("Unable to find an entry point for eglDestroyImageKHR");
+        }
+
+        let eglDestroyImageKHR: extern "C" fn(dpy: EGLDisplay, image: EGLImageKHR) -> EGLBoolean = mem::transmute(addr);
         return eglDestroyImageKHR(dpy, image);
     }
 }
 
 extern {
-    fn eglCreateImageKHR(dpy: EGLDisplay, context: EGLContext, target: EGLenum,
-                         buffer: EGLClientBuffer, attrib_list: *const EGLint) -> EGLImageKHR; 
-    fn eglDestroyImageKHR(dpy: EGLDisplay, image: EGLImageKHR) -> EGLBoolean;
+    pub fn eglGetProcAddress(procname: *const c_schar) ->
+     __eglMustCastToProperFunctionPointerType;
 }

--- a/src/eglext.rs
+++ b/src/eglext.rs
@@ -45,9 +45,9 @@ extern {}
 pub fn CreateImageKHR(dpy: EGLDisplay, context: EGLContext, target: EGLenum,
                       buffer: EGLClientBuffer, attrib_list: *const EGLint) -> EGLImageKHR {
     unsafe {
-        let name = ffi::CString::new("eglCreateImageKHR").unwrap().as_ptr();
+        let name = ffi::CString::new("eglCreateImageKHR").unwrap();
 
-        let addr = eglGetProcAddress(name as *const _);
+        let addr = eglGetProcAddress(name.as_ptr() as *const _);
 
         if addr == ptr::null() {
             panic!("Unable to find an entry point for eglCreateImageKHR");
@@ -61,9 +61,9 @@ pub fn CreateImageKHR(dpy: EGLDisplay, context: EGLContext, target: EGLenum,
 
 pub fn DestroyImageKHR(dpy: EGLDisplay, image: EGLImageKHR) -> EGLBoolean {
     unsafe {
-        let name = ffi::CString::new("eglDestroyImageKHR").unwrap().as_ptr();
+        let name = ffi::CString::new("eglDestroyImageKHR").unwrap();
 
-        let addr = eglGetProcAddress(name as *const _);
+        let addr = eglGetProcAddress(name.as_ptr() as *const _);
 
         if addr == ptr::null() {
             panic!("Unable to find an entry point for eglDestroyImageKHR");


### PR DESCRIPTION
Raw use of these functions was breaking the embedding crate (see: https://github.com/servo/servo/issues/10130). Made their load conditional on the presence of the functions.

r? @metajack @zmike

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-egl/18)

<!-- Reviewable:end -->
